### PR TITLE
fix: spaces are not allowed to be printed anymore

### DIFF
--- a/src/projects/7-todoAddV1/TodoV1/ItemForm.js
+++ b/src/projects/7-todoAddV1/TodoV1/ItemForm.js
@@ -13,7 +13,7 @@ const ItemForm = (props) => {
 
   const handleSubmit = (ev) => {
     ev.preventDefault()
-    if (!item.name) return
+    if (!item.name || !item.name.replaceAll(' ', '')) return
     props.addItem(item)
     setItem(initialFormState)
   }


### PR DESCRIPTION
Resolves #5 

Before, the form is accepting space/s and causes unnecessary blank space in the to-do list if the next input is a valid one. Now, I added a conditional that will no longer accept space/s input so it will not print in the to-do list.  