### PR TITLE
Fix: Deleted unused variables in counter and display color projects

### DIFF
--- a/src/projects/1-counter/Counter/Counter.js
+++ b/src/projects/1-counter/Counter/Counter.js
@@ -31,7 +31,7 @@
 
 // export default Counter
 
-import React, { Component, useState } from 'react'
+import React, { Component } from 'react'
 import { Link } from "react-router-dom";
 
 import Code from '../Code/Code';

--- a/src/projects/2-display-colors/Code/Code.js
+++ b/src/projects/2-display-colors/Code/Code.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import Img from '../../../assets/displayColors.png'
 
 class Code extends Component { 
     render() {


### PR DESCRIPTION
Resolves #10 

Before, deployment to netlify is failing because of the unused variables. I have deleted those unused variables in the counter and display color projects.